### PR TITLE
Incorporated Google API limit of 100 results 

### DIFF
--- a/googlecustomsearch/services/GoogleCustomSearch_SearchService.php
+++ b/googlecustomsearch/services/GoogleCustomSearch_SearchService.php
@@ -84,7 +84,15 @@ class GoogleCustomSearch_SearchService extends BaseApplicationComponent
         $results->perPage = $per_page;
         $results->start = $request_info->startIndex;
         $results->end = ($request_info->startIndex + $request_info->count) - 1;
-        $results->totalResults = $request_info->totalResults;
+        
+        /* Google allows only 100 results to be fetched for a search query over the API
+        , so we cap the totalResults to 100 if it exceeds that number */
+        if ($request_info->totalResults > 100) {
+            $results->totalResults = 100; 
+        } else {
+            $results->totalResults = $request_info->totalResults;    
+        }
+
         $results->results = array();
 
         if (isset($response->items)) {


### PR DESCRIPTION
adjusted totalResults variable to be at maximum 100, in order to cope with Google API limitations
